### PR TITLE
Tyop fix

### DIFF
--- a/external-pointers.md
+++ b/external-pointers.md
@@ -11,7 +11,7 @@ void R_SetExternalPtrTag(SEXP s, SEXP tag);
 void R_SetExternalPtrProtected(SEXP s, SEXP p);
 ```
 
-## Fianlisation
+## Finalization
 
 ```cpp
 typedef void (*R_CFinalizer_t)(SEXP);


### PR DESCRIPTION
Also switch out the s for z. I too hate non-Commonwealth spelling but given that the function names within R use it...
