### PR TITLE
Update `R_compute_identical()` documentation

### DIFF
--- a/misc.md
+++ b/misc.md
@@ -110,13 +110,14 @@ int R_system(const char *);
 
 /* R_compute_identical:  C version of identical() function
 The third arg to R_compute_identical() consists of bitmapped flags for non-default options:
-currently the first 4 default to TRUE, so the flag is set for FALSE values:
+currently the first 4 and the 6th default to TRUE, so the flag is set for FALSE values:
 1 = !NUM_EQ
 2 = !SINGLE_NA
 4 = !ATTR_AS_SET
 8 = !IGNORE_BYTECODE
 16 = !IGNORE_ENV
-Default from R's default: 15
+32 = !IGNORE_SRCREF
+Default from R's default: 16 = (0 + 0 + 0 + 0 + 16 + 0)
 */
 Rboolean R_compute_identical(SEXP, SEXP, int);
 


### PR DESCRIPTION
`R_compute_identical()`'s default `flags` value is actually 16, not 15. It also has a new argument which maps to `IGNORE_SRCREF` so I added that as well.

You can find it in the source code here:
https://github.com/wch/r-source/blob/d1bff5cbf01398eb809290ec2067cebcc786a4d2/src/main/identical.c#L74

And here is rlang using 16, not 15:
https://github.com/r-lib/rlang/blob/1e12fe98b43474cf1e4468ad38f598b48a4b2ca7/src/lib/sexp.h#L93