### PR TITLE
Add `R_NewEnv`, a C version of `new.env()`

### DIFF
--- a/environments.md
+++ b/environments.md
@@ -10,8 +10,15 @@ Rboolean Rf_isEnvironment(SEXP x); // (TYPEOF(x) == ENVSXP)
 * `R_BaseNamespace`: The (fake) namespace for base
 * `R_NamespaceRegistry`: Registry for registered namespaces
 * `R_GetCurrentEnv`: Retrieve the current environment `R (>= 3.6.0)`
+* `R_NewEnv`: Create a new environment `R (>= 4.1.0)`
 
 Environments are commonly called `rho` in the sources.
+
+## Creation (R >= 4.1.0)
+
+``` cpp
+SEXP R_NewEnv(SEXP enclos, int hash, ins size);
+```
 
 ## Get and set objects in environment
 


### PR DESCRIPTION
Writing R Extensions now has this sentence:

> At times it may also be useful to create a new environment frame in C code. `R_NewEnv` is a C version of the R function `new.env`:
> 
> ``` r
> SEXP R_NewEnv(SEXP enclos, int hash, ins size)
> ```

It seems this was added by the following commit (without a notice on changelog...?), and the API is available as of R 4.1. I haven't used this yet, but probably it would be nice to cover this in R internals.

https://github.com/wch/r-source/commit/8a322e786068ec2e23324e61821ff666d0b6e329