### PR TITLE
Update environments.md

### DIFF
--- a/environments.md
+++ b/environments.md
@@ -117,7 +117,7 @@ void (SET_TRUELENGTH)(SEXP x, int v);
 ### Hash
 
 ```cpp
-SEXP HASHTAB(SEXP x);
+SEXP HASHTAB(SEXP x); // no longer part of the API you can use...
 void SET_HASHTAB(SEXP x, SEXP v);
 
 int  HASHASH(SEXP x);


### PR DESCRIPTION
As a note, `HASHTAB` will now raise a warning in CRAN saying it is no longer part of the exported API, and I guess it can no longer be used.  I'm unsure about the rest of the functions here.

For now, I'm simply commenting this as things may change.